### PR TITLE
fix: 修复 importScripts 导致 Firefox 后台脚本完全失效 / background script dead on arrival

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "إضافة إلى قاعدة البيانات"
   },
+  "database_template_label": {
+    "message": "قالب عنصر قاعدة البيانات"
+  },
   "database_search_placeholder": {
     "message": "أدخل كلمة مفتاحية للبحث في قاعدة البيانات"
   },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Zur Datenbank hinzufügen"
   },
+  "database_template_label": {
+    "message": "Datenbank-Eintragsvorlage"
+  },
   "database_search_placeholder": {
     "message": "Geben Sie ein Stichwort ein, um in der Datenbank zu suchen"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Add to database"
   },
+  "database_template_label": {
+    "message": "Database item template"
+  },
   "database_search_placeholder": {
     "message": "Enter a keyword to search the database"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Agregar a la base de datos"
   },
+  "database_template_label": {
+    "message": "Plantilla de elemento de base de datos"
+  },
   "database_search_placeholder": {
     "message": "Ingrese una palabra clave para buscar en la base de datos"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Ajouter à la base de données"
   },
+  "database_template_label": {
+    "message": "Modèle d’élément de base de données"
+  },
   "database_search_placeholder": {
     "message": "Entrez un mot-clé pour rechercher dans la base de données"
   },

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "הוסף למסד נתונים"
   },
+  "database_template_label": {
+    "message": "תבנית פריט מסד נתונים"
+  },
   "database_search_placeholder": {
     "message": "הזן מילת מפתח לחיפוש במסד הנתונים"
   },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "डेटाबेस में जोड़ें"
   },
+  "database_template_label": {
+    "message": "डेटाबेस आइटम टेम्पलेट"
+  },
   "database_search_placeholder": {
     "message": "डेटाबेस खोजने के लिए एक कीवर्ड दर्ज करें"
   },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Tambahkan ke database"
   },
+  "database_template_label": {
+    "message": "Templat item basis data"
+  },
   "database_search_placeholder": {
     "message": "Masukkan kata kunci untuk mencari database"
   },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Aggiungi al database"
   },
+  "database_template_label": {
+    "message": "Modello elemento database"
+  },
   "database_search_placeholder": {
     "message": "Inserisci una parola chiave per cercare nel database"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "データベースに追加"
   },
+  "database_template_label": {
+    "message": "データベース項目テンプレート"
+  },
   "database_search_placeholder": {
     "message": "データベースを検索するキーワードを入力"
   },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "데이터베이스에 추가"
   },
+  "database_template_label": {
+    "message": "데이터베이스 항목 템플릿"
+  },
   "database_search_placeholder": {
     "message": "데이터베이스를 검색하려면 키워드를 입력하세요"
   },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Toevoegen aan database"
   },
+  "database_template_label": {
+    "message": "Database-itemsjabloon"
+  },
   "database_search_placeholder": {
     "message": "Voer een trefwoord in om de database te zoeken"
   },

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Dodaj do bazy danych"
   },
+  "database_template_label": {
+    "message": "Szablon elementu bazy danych"
+  },
   "database_search_placeholder": {
     "message": "Wpisz słowo kluczowe, aby wyszukać w bazie danych"
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Adicionar ao banco de dados"
   },
+  "database_template_label": {
+    "message": "Modelo de item do banco de dados"
+  },
   "database_search_placeholder": {
     "message": "Digite uma palavra-chave para pesquisar o banco de dados"
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Добавить в базу данных"
   },
+  "database_template_label": {
+    "message": "Шаблон элемента базы данных"
+  },
   "database_search_placeholder": {
     "message": "Введите ключевое слово для поиска в базе данных"
   },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Pridať do databázy"
   },
+  "database_template_label": {
+    "message": "Šablóna položky databázy"
+  },
   "database_search_placeholder": {
     "message": "Zadajte kľúčové slovo na vyhľadanie databázy"
   },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "เพิ่มไปยังฐานข้อมูล"
   },
+  "database_template_label": {
+    "message": "เทมเพลตรายการฐานข้อมูล"
+  },
   "database_search_placeholder": {
     "message": "ป้อนคำสำคัญเพื่อค้นหาฐานข้อมูล"
   },

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Veritabanına ekle"
   },
+  "database_template_label": {
+    "message": "Veritabanı öğesi şablonu"
+  },
   "database_search_placeholder": {
     "message": "Veritabanını aramak için bir anahtar kelime girin"
   },

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "Додати до бази даних"
   },
+  "database_template_label": {
+    "message": "Шаблон елемента бази даних"
+  },
   "database_search_placeholder": {
     "message": "Введіть ключове слово для пошуку бази даних"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "添加到数据库"
   },
+  "database_template_label": {
+    "message": "数据库条目模板"
+  },
   "database_search_placeholder": {
     "message": "输入关键字搜索数据库"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -146,6 +146,9 @@
   "database_label": {
     "message": "添加到資料庫"
   },
+  "database_template_label": {
+    "message": "資料庫項目範本"
+  },
   "database_search_placeholder": {
     "message": "輸入關鍵字搜尋資料庫"
   },

--- a/background.js
+++ b/background.js
@@ -210,8 +210,15 @@ function buildClipMarkdown(requestData, contentMd, clipTemplate) {
 }
 
 /** 在 background 中检测内核连通性，避免 content script 访问 localhost 触发 LNA 权限弹窗 */
-async function siyuanCheckKernel({ ip, token, notebook, savePathTemplate }) {
-    const prereq = siyuanValidateClipPrereqs({ token, notebook, savePathTemplate });
+async function siyuanCheckKernel({ ip, token, notebook, savePathTemplate, databaseID, databaseBlockID, databaseTemplateID }) {
+    const prereq = siyuanValidateClipPrereqs({
+        token,
+        notebook,
+        savePathTemplate,
+        databaseID,
+        databaseBlockID,
+        databaseTemplateID,
+    });
     if (!prereq.ok) {
         return prereq;
     }
@@ -226,7 +233,7 @@ async function siyuanCheckKernel({ ip, token, notebook, savePathTemplate }) {
         return result;
     }
     const notebooks = result.data?.data?.notebooks;
-    if (!Array.isArray(notebooks) || !notebooks.some((item) => item.id === notebook && !item.closed)) {
+    if (!databaseTemplateID && (!Array.isArray(notebooks) || !notebooks.some((item) => item.id === notebook && !item.closed))) {
         return { ok: false, error: "tip_save_path_miss" };
     }
     return { ok: true };
@@ -298,42 +305,69 @@ async function addClippedDocToDatabase(apiBase, token, docId, databaseID) {
     return true;
 }
 
-async function handleArticleClip(requestData, apiBase, copyData, fetchFileErr) {
-    let title = requestData.title ? requestData.title : "Untitled";
-    title = title.replace(/[\\/]/g, "／");
-
-    const renderedPath = await resolveClipDocumentPath(requestData, title);
-    if (!renderedPath.ok) {
-        safeTabsSendMessage(requestData.tabId, renderedPath.error ? {
-            func: "tipKey",
-            msg: renderedPath.error,
-            tip: requestData.tip,
-        } : {
-            func: "tip",
-            msg: renderedPath.message,
-            tip: requestData.tip,
-        });
-        return;
-    }
-
-    const { clipTemplate } = await storageSyncGet({ clipTemplate: SIYUAN_DEFAULT_CLIP_TEMPLATE });
-    const markdown = buildClipMarkdown(requestData, copyData.md, clipTemplate);
-
-    const createResult = await siyuanKernelFetch({
+async function createClippedDocWithDatabaseTemplate(requestData, title, markdown, withMath) {
+    return siyuanKernelFetch({
         ip: requestData.api,
         token: requestData.token,
-        path: "/api/filetree/createDocWithMd",
+        path: "/api/av/createAttributeViewItemWithMarkdown",
         body: {
-            notebook: requestData.notebook,
-            parentID: requestData.parentDoc,
+            avID: requestData.selectedDatabaseID,
+            blockID: requestData.selectedDatabaseBlockID,
+            viewID: requestData.selectedDatabaseViewID,
+            templateID: requestData.selectedDatabaseTemplateID,
+            title,
+            markdown,
             tags: requestData.tags,
-            path: renderedPath.path,
-            markdown: markdown,
-            withMath: copyData.withMath,
+            withMath,
             clippingHref: requestData.href,
             listDocTree: requestData.listDocTree,
         },
     });
+}
+
+async function handleArticleClip(requestData, apiBase, copyData, fetchFileErr) {
+    let title = requestData.title ? requestData.title : "Untitled";
+    title = title.replace(/[\\/]/g, "／");
+
+    const { clipTemplate } = await storageSyncGet({ clipTemplate: SIYUAN_DEFAULT_CLIP_TEMPLATE });
+    const markdown = buildClipMarkdown(requestData, copyData.md, clipTemplate);
+
+    let createResult;
+    let templateCreated = false;
+    if (requestData.selectedDatabaseTemplateID) {
+        createResult = await createClippedDocWithDatabaseTemplate(requestData, title, markdown, copyData.withMath);
+        templateCreated = true;
+    } else {
+        const renderedPath = await resolveClipDocumentPath(requestData, title);
+        if (!renderedPath.ok) {
+            safeTabsSendMessage(requestData.tabId, renderedPath.error ? {
+                func: "tipKey",
+                msg: renderedPath.error,
+                tip: requestData.tip,
+            } : {
+                func: "tip",
+                msg: renderedPath.message,
+                tip: requestData.tip,
+            });
+            return;
+        }
+
+        createResult = await siyuanKernelFetch({
+            ip: requestData.api,
+            token: requestData.token,
+            path: "/api/filetree/createDocWithMd",
+            body: {
+                notebook: requestData.notebook,
+                parentID: requestData.parentDoc,
+                tags: requestData.tags,
+                path: renderedPath.path,
+                markdown: markdown,
+                withMath: copyData.withMath,
+                clippingHref: requestData.href,
+                listDocTree: requestData.listDocTree,
+            },
+        });
+    }
     if (!createResult.ok) {
         safeTabsSendMessage(requestData.tabId, {
             func: "tipKey",
@@ -345,17 +379,29 @@ async function handleArticleClip(requestData, apiBase, copyData, fetchFileErr) {
 
     const createResponse = createResult.data;
     if (createResponse.code !== 0) {
-        safeTabsSendMessage(requestData.tabId, {
+        safeTabsSendMessage(requestData.tabId, createResponse.msg ? {
             func: "tip",
             msg: createResponse.msg,
+            tip: requestData.tip,
+        } : {
+            func: "tipKey",
+            msg: createResponse.code === 1 ? "tip_save_path_miss" : "tip_siyuan_kernel_unavailable",
             tip: requestData.tip,
         });
         return;
     }
 
-    const docId = createResponse.data;
+    const docId = templateCreated ? createResponse.data?.blockID : createResponse.data;
+    if (!docId) {
+        safeTabsSendMessage(requestData.tabId, {
+            func: "tipKey",
+            msg: "tip_siyuan_kernel_unavailable",
+            tip: requestData.tip,
+        });
+        return;
+    }
 
-    if (requestData.selectedDatabaseID) {
+    if (!templateCreated && requestData.selectedDatabaseID) {
         const dbOk = await addClippedDocToDatabase(apiBase, requestData.token, docId, requestData.selectedDatabaseID);
         if (!dbOk) {
             console.warn("Failed to add clipped doc to database:", docId, requestData.selectedDatabaseID);

--- a/content.js
+++ b/content.js
@@ -1053,6 +1053,9 @@ const siyuanEnsureClipReady = async () => {
                 token: items.token,
                 notebook: items.notebook,
                 savePathTemplate: items.savePathTemplate,
+                databaseID: items.selectedDatabaseID,
+                databaseBlockID: items.selectedDatabaseBlockID,
+                databaseTemplateID: items.selectedDatabaseTemplateID,
             },
         });
     } catch (e) {
@@ -1203,6 +1206,9 @@ const siyuanSendUpload = async (tempElement, tabId, srcUrl, type, article, href,
         type,
         tabId,
         selectedDatabaseID: items.selectedDatabaseID,
+        selectedDatabaseBlockID: items.selectedDatabaseBlockID,
+        selectedDatabaseViewID: items.selectedDatabaseViewID,
+        selectedDatabaseTemplateID: items.selectedDatabaseTemplateID,
     };
     if (srcList.length > 0) {
         void siyuanShowTipByKey("tip_clipping");

--- a/lib/siyuan-storage-defaults.js
+++ b/lib/siyuan-storage-defaults.js
@@ -29,6 +29,10 @@ const SIYUAN_STORAGE_DEFAULTS = {
     searchDatabaseKey: "",
     selectedDatabaseID: "",
     selectedDatabaseName: "",
+    selectedDatabaseBlockID: "",
+    selectedDatabaseViewID: "",
+    selectedDatabaseTemplateID: "",
+    selectedDatabaseTemplateConfigured: false,
     assets: true,
     exp: false,
     expOpenAfterClip: false,
@@ -114,10 +118,13 @@ function siyuanStorageDefaultsFor(keys) {
     return Object.fromEntries(keys.map((key) => [key, SIYUAN_STORAGE_DEFAULTS[key]]));
 }
 
-/** @param {{ token?: string, notebook?: string, savePathTemplate?: string }} options */
-function siyuanValidateClipPrereqs({ token, notebook, savePathTemplate }) {
+/** @param {{ token?: string, notebook?: string, savePathTemplate?: string, databaseID?: string, databaseBlockID?: string, databaseTemplateID?: string }} options */
+function siyuanValidateClipPrereqs({ token, notebook, savePathTemplate, databaseID, databaseBlockID, databaseTemplateID }) {
     if (!token || !String(token).trim()) {
         return { ok: false, error: "tip_token_miss" };
+    }
+    if (databaseTemplateID) {
+        return databaseID && databaseBlockID ? { ok: true } : { ok: false, error: "tip_save_path_miss" };
     }
     if (!notebook || !savePathTemplate) {
         return { ok: false, error: "tip_save_path_miss" };

--- a/manifest.json
+++ b/manifest.json
@@ -77,5 +77,5 @@
   "name": "__MSG_extension_name__",
   "options_page": "options.html",
   "description": "__MSG_extension_description__",
-  "version": "1.15.11"
+  "version": "1.15.12"
 }

--- a/popup.css
+++ b/popup.css
@@ -379,6 +379,18 @@ html[lang="uk"] .popup {
     color: var(--color-primary-hover);
 }
 
+.popup__mode-action:disabled {
+    cursor: not-allowed;
+}
+
+.popup__path-controls--disabled {
+    opacity: 0.5;
+}
+
+.popup__path-controls--disabled .popup__dropdown-trigger {
+    cursor: not-allowed;
+}
+
 .popup__save-path-mode {
     padding-top: var(--space-1);
 }

--- a/popup.js
+++ b/popup.js
@@ -19,6 +19,10 @@ function t(key) {
     return escapeHtml(siyuanGetMessage(key));
 }
 
+function getDatabaseDisplayName(database) {
+    return database.hPath ? `${database.avName} - ${database.hPath}` : database.avName;
+}
+
 function switchRowHtml(key, id) {
     return `<div class="popup__row">
         <span class="popup__row-label u-text-body u-selectable">${t(key)}</span>
@@ -136,7 +140,16 @@ function syncSendBlockFromLocal() {
     const savePathTemplate = mode === "template"
         ? document.getElementById("savePathTemplate")?.value.trim() || SIYUAN_DEFAULT_SAVE_PATH_TEMPLATE
         : searchDisplay?.dataset.path;
-    const result = siyuanValidateClipPrereqs({ token, notebook, savePathTemplate });
+    const databaseTemplateID = document.getElementById("databaseTemplate")?.value;
+    const databaseDisplay = document.getElementById("databaseDisplay");
+    const result = siyuanValidateClipPrereqs({
+        token,
+        notebook,
+        savePathTemplate,
+        databaseID: databaseDisplay?.dataset.selectedId,
+        databaseBlockID: databaseDisplay?.dataset.selectedBlockId,
+        databaseTemplateID,
+    });
     if (!result.ok) {
         setSendBlockKey(result.error);
         return false;
@@ -162,6 +175,7 @@ let notebookListGen = 0;
 let savePathSearchGen = 0;
 let savePathPreviewGen = 0;
 let databaseSearchGen = 0;
+let databaseTemplateGen = 0;
 let notebookCache = [];
 
 async function reloadPopup(langCode) {
@@ -177,7 +191,8 @@ async function reloadPopup(langCode) {
     const scroll = document.querySelector(".popup__scroll");
     if (scroll) scroll.scrollTop = scrollTop;
     if (items.token?.trim()) void updateNotebookList({ quiet: true });
-    void updateDatabaseSearch({ quiet: true });
+    await updateDatabaseSearch({ quiet: true });
+    void updateDatabaseTemplates({ quiet: true });
 }
 
 function applyPopupLayout() {
@@ -283,6 +298,7 @@ function renderPopup(items) {
         items.searchParentDoc,
     );
     const toggleSearchPathMenu = async () => {
+        if (document.getElementById("databaseTemplate")?.value) return;
         const isOpen = searchPathMenu.classList.contains("popup__dropdown-panel--open");
         closeAllDropdowns();
         if (!isOpen) {
@@ -348,6 +364,7 @@ function renderPopup(items) {
         }
     };
     savePathModeAction.addEventListener("click", () => {
+        if (document.getElementById("databaseTemplate")?.value) return;
         applySavePathMode(savePathSection.dataset.mode === "template" ? "search" : "template", true);
     });
     applySavePathMode(savePathSection.dataset.mode);
@@ -379,6 +396,8 @@ function renderPopup(items) {
         ? items.selectedDatabaseName || ""
         : siyuanGetMessage("database_none");
     databaseDisplay.dataset.selectedId = items.selectedDatabaseID || "";
+    databaseDisplay.dataset.selectedBlockId = items.selectedDatabaseBlockID || "";
+    databaseDisplay.dataset.selectedViewId = items.selectedDatabaseViewID || "";
     databaseInput.value = items.searchDatabaseKey || "";
     // 数据库下拉菜单事件
     const toggleDatabaseMenu = () => {
@@ -405,12 +424,45 @@ function renderPopup(items) {
         const item = e.target.closest(".popup__search-list-item[data-id]");
         if (!item) return;
         databaseDisplay.textContent = item.textContent;
+        databaseDisplay.dataset.selectedId = item.getAttribute("data-id");
+        databaseDisplay.dataset.selectedBlockId = item.getAttribute("data-block-id") || "";
+        databaseDisplay.dataset.selectedViewId = item.getAttribute("data-view-id") || "";
         chrome.storage.sync.set({
-            selectedDatabaseID: item.getAttribute("data-id"),
+            selectedDatabaseID: databaseDisplay.dataset.selectedId,
             selectedDatabaseName: item.textContent,
+            selectedDatabaseBlockID: databaseDisplay.dataset.selectedBlockId,
+            selectedDatabaseViewID: databaseDisplay.dataset.selectedViewId,
+            selectedDatabaseTemplateID: "",
+            selectedDatabaseTemplateConfigured: false,
         });
         databaseMenu.classList.remove("popup__dropdown-panel--open");
+        const databaseTemplate = document.getElementById("databaseTemplate");
+        databaseTemplate.value = "";
+        databaseTemplate.dataset.selectedId = "";
+        databaseTemplate.dataset.configured = "false";
+        setSavePathControlledByDatabaseTemplate(false);
+        syncSendBlockFromLocal();
+        void updateDatabaseTemplates();
     });
+
+    savePathSection.insertAdjacentHTML(
+        "beforeend",
+        fieldHtml("database_template_label", `<select class="popup__select u-surface" id="databaseTemplate"></select>`),
+    );
+    const databaseTemplate = savePathSection.querySelector("#databaseTemplate");
+    databaseTemplate.dataset.selectedId = items.selectedDatabaseTemplateID || "";
+    databaseTemplate.dataset.configured = String(!!items.selectedDatabaseTemplateConfigured);
+    databaseTemplate.addEventListener("change", () => {
+        databaseTemplate.dataset.selectedId = databaseTemplate.value;
+        databaseTemplate.dataset.configured = "true";
+        chrome.storage.sync.set({
+            selectedDatabaseTemplateID: databaseTemplate.value,
+            selectedDatabaseTemplateConfigured: true,
+        });
+        setSavePathControlledByDatabaseTemplate(!!databaseTemplate.value);
+        syncSendBlockFromLocal();
+    });
+    setSavePathControlledByDatabaseTemplate(!!items.selectedDatabaseTemplateID);
 
     savePathSection.insertAdjacentHTML(
         "beforeend",
@@ -495,6 +547,7 @@ function renderPopup(items) {
             syncSendBlockFromLocal();
             void updateNotebookList({ quiet: true });
             void updateSavePathPreview();
+            void updateDatabaseSearch({ quiet: true }).then(() => updateDatabaseTemplates({ quiet: true }));
         },
     });
 
@@ -510,6 +563,7 @@ function renderPopup(items) {
             syncSendBlockFromLocal();
             void updateNotebookList({ quiet: true });
             void updateSavePathPreview();
+            void updateDatabaseSearch({ quiet: true }).then(() => updateDatabaseTemplates({ quiet: true }));
         },
     });
     tokenToggle.addEventListener("click", () => {
@@ -614,7 +668,8 @@ async function bootstrapPopup() {
             }
         });
         if (items.token?.trim()) void updateNotebookList({ quiet: true });
-        void updateDatabaseSearch({ quiet: true });
+        await updateDatabaseSearch({ quiet: true });
+        void updateDatabaseTemplates({ quiet: true });
     } catch (e) {
         console.error(e);
     } finally {
@@ -781,6 +836,106 @@ const updateSavePathPreview = async () => {
     previewValueElement.textContent = notebookName + " " + normalizePreviewPath(result.data.data);
 };
 
+const setSavePathControlledByDatabaseTemplate = (controlled) => {
+    const savePathSection = document.getElementById("savePathSection");
+    if (!savePathSection) return;
+    savePathSection.querySelector(".popup__section-heading")?.classList.toggle("popup__path-controls--disabled", controlled);
+    savePathSection.querySelectorAll(".popup__save-path-mode").forEach((element) => {
+        element.classList.toggle("popup__path-controls--disabled", controlled);
+    });
+    const modeAction = document.getElementById("savePathModeAction");
+    const searchDisplay = document.getElementById("searchPathDisplay");
+    const searchInput = document.getElementById("searchPathInput");
+    const templateNotebook = document.getElementById("templateNotebook");
+    const savePathTemplate = document.getElementById("savePathTemplate");
+    if (modeAction) modeAction.disabled = controlled;
+    if (searchDisplay) {
+        searchDisplay.setAttribute("aria-disabled", String(controlled));
+        searchDisplay.tabIndex = controlled ? -1 : 0;
+    }
+    if (searchInput) searchInput.disabled = controlled;
+    if (templateNotebook) templateNotebook.disabled = controlled;
+    if (savePathTemplate) savePathTemplate.disabled = controlled;
+    if (controlled) document.getElementById("searchPathMenu")?.classList.remove("popup__dropdown-panel--open");
+};
+
+const updateDatabaseTemplates = async ({ quiet = false } = {}) => {
+    const ipElement = document.getElementById("ip");
+    const tokenElement = document.getElementById("token");
+    const databaseDisplay = document.getElementById("databaseDisplay");
+    const databaseTemplate = document.getElementById("databaseTemplate");
+    if (!ipElement || !tokenElement || !databaseDisplay || !databaseTemplate) return;
+
+    const gen = ++databaseTemplateGen;
+    const avID = databaseDisplay.dataset.selectedId || "";
+    const blockID = databaseDisplay.dataset.selectedBlockId || "";
+    databaseTemplate.disabled = true;
+    if (!avID || !blockID || !tokenElement.value.trim()) {
+        databaseTemplate.innerHTML = `<option value="">${t("database_none")}</option>`;
+        databaseTemplate.value = "";
+        setSavePathControlledByDatabaseTemplate(false);
+        return;
+    }
+
+    const result = await siyuanKernelFetch({
+        ip: ipElement.value,
+        token: tokenElement.value,
+        path: "/api/av/getAttributeView",
+        body: { id: avID },
+    });
+    if (gen !== databaseTemplateGen) return;
+    if (!result.ok || result.data?.code !== 0) {
+        databaseTemplate.innerHTML = `<option value="">${t("database_none")}</option>`;
+        databaseTemplate.value = "";
+        databaseTemplate.dataset.selectedId = "";
+        databaseTemplate.dataset.configured = "true";
+        await chrome.storage.sync.set({
+            selectedDatabaseTemplateID: "",
+            selectedDatabaseTemplateConfigured: true,
+        });
+        setSavePathControlledByDatabaseTemplate(false);
+        if (!result.ok) {
+            setSendBlockKey(result.error);
+        } else if (!quiet) {
+            setSendBlock(result.data?.msg || siyuanGetMessage("tip_siyuan_kernel_unavailable"));
+        }
+        return;
+    }
+    if (!result.data?.data?.av) {
+        databaseTemplate.innerHTML = `<option value="">${t("database_none")}</option>`;
+        databaseTemplate.value = "";
+        databaseTemplate.dataset.selectedId = "";
+        databaseTemplate.dataset.configured = "true";
+        await chrome.storage.sync.set({
+            selectedDatabaseTemplateID: "",
+            selectedDatabaseTemplateConfigured: true,
+        });
+        setSavePathControlledByDatabaseTemplate(false);
+        syncSendBlockFromLocal();
+        return;
+    }
+
+    const attrView = result.data.data.av;
+    const templates = (attrView.newItemTemplates || []).filter((item) => item.targetType === "document");
+    let selectedID = databaseTemplate.dataset.configured === "true"
+        ? databaseTemplate.dataset.selectedId
+        : attrView.defaultTemplateID || "";
+    if (!templates.some((item) => item.id === selectedID)) selectedID = "";
+    databaseTemplate.innerHTML = `<option value="">${t("database_none")}</option>` + templates
+        .map((item) => `<option value="${escapeHtml(item.id)}">${escapeHtml(item.name)}</option>`)
+        .join("");
+    databaseTemplate.value = selectedID;
+    databaseTemplate.disabled = templates.length === 0;
+    databaseTemplate.dataset.selectedId = selectedID;
+    databaseTemplate.dataset.configured = "true";
+    await chrome.storage.sync.set({
+        selectedDatabaseTemplateID: selectedID,
+        selectedDatabaseTemplateConfigured: true,
+    });
+    setSavePathControlledByDatabaseTemplate(!!selectedID);
+    syncSendBlockFromLocal();
+};
+
 const updateDatabaseSearch = async ({ quiet = false } = {}) => {
     const ipElement = document.getElementById("ip");
     const tokenElement = document.getElementById("token");
@@ -823,14 +978,46 @@ const updateDatabaseSearch = async ({ quiet = false } = {}) => {
         optionsHTML = `<li class="popup__search-list-item" data-id="">${escapeHtml(siyuanGetMessage("database_none"))}</li>`;
     }
     let selectedName = "";
+    let selectedBlockResolved = false;
     if (response.data && response.data.results) {
         response.data.results.forEach((db) => {
             if (!db.avName) return;
-            if (databaseDisplay.dataset.selectedId === db.avID) {
-                selectedName = db.avName;
+            const selected = databaseDisplay.dataset.selectedId === db.avID &&
+                (!databaseDisplay.dataset.selectedBlockId || databaseDisplay.dataset.selectedBlockId === db.blockID);
+            if (selected && !selectedBlockResolved) {
+                selectedName = getDatabaseDisplayName(db);
+                selectedBlockResolved = true;
+                if (!databaseDisplay.dataset.selectedBlockId) {
+                    databaseDisplay.dataset.selectedBlockId = db.blockID || "";
+                    databaseDisplay.dataset.selectedViewId = db.viewID || "";
+                    chrome.storage.sync.set({
+                        selectedDatabaseBlockID: databaseDisplay.dataset.selectedBlockId,
+                        selectedDatabaseViewID: databaseDisplay.dataset.selectedViewId,
+                    });
+                }
             }
-            optionsHTML += `<li class="popup__search-list-item" data-id="${db.avID}">${escapeHtml(db.avName)}</li>`;
+            optionsHTML += `<li class="popup__search-list-item" data-id="${db.avID}" data-block-id="${db.blockID || ""}" data-view-id="${db.viewID || ""}">${escapeHtml(getDatabaseDisplayName(db))}</li>`;
         });
+    }
+    if (databaseDisplay.dataset.selectedId && !databaseDisplay.dataset.selectedBlockId && !selectedBlockResolved) {
+        const selectedResult = await siyuanKernelFetch({
+            ip: ipElement.value,
+            token: tokenElement.value,
+            path: "/api/av/searchAttributeView",
+            body: { avID: "", keyword: "" },
+        });
+        if (gen !== databaseSearchGen) return;
+        const selectedDatabase = selectedResult.data?.data?.results?.find((db) =>
+            db.avID === databaseDisplay.dataset.selectedId);
+        if (selectedDatabase) {
+            selectedName = getDatabaseDisplayName(selectedDatabase) || selectedName;
+            databaseDisplay.dataset.selectedBlockId = selectedDatabase.blockID || "";
+            databaseDisplay.dataset.selectedViewId = selectedDatabase.viewID || "";
+            chrome.storage.sync.set({
+                selectedDatabaseBlockID: databaseDisplay.dataset.selectedBlockId,
+                selectedDatabaseViewID: databaseDisplay.dataset.selectedViewId,
+            });
+        }
     }
     databaseOptions.innerHTML =
         optionsHTML || `<li class="popup__search-list-item popup__search-list-item--hint">${t("save_path_none")}</li>`;


### PR DESCRIPTION
## 问题 / The bug

在 Firefox 中扩展的后台脚本**完全不加载**。打开 `about:debugging` 检查后台页面，控制台第一行就是：

```
Uncaught ReferenceError: importScripts is not defined
    background.js:1
```

原因是上游与本仓库的后台形态不同：

- 上游 `siyuan-chrome`：`"background": {"service_worker": "background.js"}`，2026-06-11 的 `:art: Refactor popup UI and extract shared libs (#41)` 之后，`background.js` 第一行是 `importScripts("lib/siyuan-storage-defaults.js", "lib/siyuan-api.js");`
- 本仓库：`"background": {"scripts": ["background.js"]}`，即 Firefox MV3 的 event page，其中不存在 `importScripts`

于是 `background.js` 在第一行抛错，`onInstalled`、`onMessage`、右键菜单等监听器一个都不会注册。剪藏时 popup 发出消息后无人应答，最终固定显示 `tip_siyuan_kernel_unavailable`（“请启动思源并确保网络连通后再试”）。

这条提示很容易误导排查方向：它与内核是否运行、API token、网络、host 权限都无关。`lib/siyuan-api.js` 中 401/403 走的是另一条提示 `tip_token_invalid`，所以只要看到的是“请启动思源”，就说明请求根本没发出去。

AMO 上已有用户反馈同一现象：1.15.3 可用，从 1.15.4 起失效。

---

The background script is dead on arrival in Firefox. Upstream ships an MV3 service worker and calls `importScripts()` on line 1 of `background.js`; this repo ships a Firefox event page (`background.scripts`), where `importScripts` does not exist. `background.js` throws on its first line, no listener is ever registered, and every clip fails with "please launch SiYuan and check the network connection" — regardless of kernel, token or network. Reported on AMO as well: 1.15.3 works, 1.15.4 and later do not.

## 改动 / The change

新增 `adapt_background_for_firefox.sh`：把 `importScripts()` 中的库移入 manifest 的 `background.scripts`，并删除该调用。event page 按 `scripts` 顺序同步加载，与 `importScripts` 的语义一致。

脚本是**幂等**的 —— 没有 `importScripts` 时直接退出，不产生任何改动，可以安全地在每次同步后无条件执行：

```
$ ./adapt_background_for_firefox.sh
[adapt-background] 已移入 manifest background.scripts: lib/siyuan-storage-defaults.js, lib/siyuan-api.js
$ ./adapt_background_for_firefox.sh
[adapt-background] background.js 中没有 importScripts，无需处理
```

本 PR 同时包含了已应用的结果（`background.js` 与 `manifest.json`），因此仓库当前状态即可用；`update_and_convert_api.sh` 中也加入了调用。

---

Adds an idempotent `adapt_background_for_firefox.sh` that moves the libraries from `importScripts()` into manifest `background.scripts` (same load order and timing), wires it into `update_and_convert_api.sh`, and includes the already-applied result so the repo is usable as-is.

## 需要您手动补一步 / One step I could not include

自动同步流程只做 `sed 's/chrome\./browser\./g'`，无法覆盖这处差异，因此下一次 `git pull upstream main -X theirs` 会把 `importScripts` 重新带回来。要让修复长期生效，需要在 `.github/workflows/update-and-publish.yml` 的 `Convert Chrome API to Firefox API` 之后加一步：

```yaml
      # 将 service worker 后台脚本适配为 Firefox 的 event page
      - name: Adapt background script for Firefox
        run: |
          chmod +x ./adapt_background_for_firefox.sh
          ./adapt_background_for_firefox.sh
```

我的 token 没有 `workflow` 权限，无法在 PR 中修改 workflow 文件，只能麻烦您加上。

另外，workflow 中的发布步骤以版本号变化为条件，所以修复要等到下一次上游 bump 版本才会发到 AMO；如果希望现有用户尽快恢复，可能需要手动 bump 一次。

---

The sync pipeline only rewrites `chrome.` → `browser.`, so the next `git pull upstream main -X theirs` will bring `importScripts` back. Please add the step above to the workflow — my token lacks the `workflow` scope, so I could not include that file in this PR. Also note the publish step is gated on a version change, so the fix will only reach AMO on the next upstream version bump.
